### PR TITLE
Bugfix/index out of bounds exception on duplicaterow

### DIFF
--- a/JBig2Decoder.NETStandard/Images/JBig2Image.cs
+++ b/JBig2Decoder.NETStandard/Images/JBig2Image.cs
@@ -1282,6 +1282,11 @@ namespace JBig2Decoder.NETStandard
             //			setPixelbyte(i, yDest, getPixelbyte(i, ySrc));
             //			i += 8;
             //		}
+            if (ySrc < 0)
+            {
+	            ySrc = 0;
+            }
+
             for (int i = 0; i < width; i++)
             {
                 SetPixel(i, yDest, GetPixel(i, ySrc));

--- a/JBig2Decoder.NETStandard/Images/JBig2Image.cs
+++ b/JBig2Decoder.NETStandard/Images/JBig2Image.cs
@@ -1284,7 +1284,7 @@ namespace JBig2Decoder.NETStandard
             //		}
             if (ySrc < 0)
             {
-	            ySrc = 0;
+                ySrc = 0;
             }
 
             for (int i = 0; i < width; i++)


### PR DESCRIPTION
A JB2 file generated by a Xerox scanner caused an IndexOutOfBoundsException @ DuplicateRow on the initial row.
A fix/workaround to prevent this.